### PR TITLE
Modified Netlify CMS website, and added Netlify hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ We don't want to repeat that content, _go read the original!_
 - **GitHub** : (web: [github.com](https://github.com))
 - **GitLab** : (web: [gitlab.com](https://gitlab.com))
 - **Neocities** : (web: [neocities.org](https://neocities.org))
+- **Netlify** : (web: [netlify.com](https://www.netlify.com))
 
 ## Commercial hosting
 - **Aerobatic** : (web: [aerobatic.com](http://www.aerobatic.com))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We don't want to repeat that content, _go read the original!_
 - **Forestry** (web: [forestry.io](https://forestry.io)) - A CMS for Jekyll and Hugo sites. Host anywhere (GitHub Pages, Amazon S3, FTP, etc) and access your static CMS from `site.com/admin/`.
 - **Grav** : (web: [getgrav.org](https://getgrav.org/)) - Modern, Crazy Fast, Ridiculously Easy and Amazingly Powerful Flat-File CMS.
 - **Jekyll Admin** (web: [jekyll.github.io/jekyll-admin](https://jekyll.github.io/jekyll-admin/)) - A Jekyll plugin that provides users with a traditional CMS-style graphical interface to author content and administer Jekyll sites.  Developed on GitHub: https://github.com/jekyll/jekyll-admin
-- **Netlify** : (web: [netlify.com](https://www.netlify.com/)) - An open source, and commercially supported, CMS for Static Site Generators.  Developed on GitHub: https://github.com/netlify/netlify-cms
+- **Netlify** : (web: [netlifycms.org](https://www.netlifycms.org/)) - An open source, and commercially supported, CMS for Static Site Generators.  Developed on GitHub: https://github.com/netlify/netlify-cms
 - **Prose** : (web: [prose.io](http://prose.io/)) - An open source CMS for GitHub pages.  Developed on GitHub: https://github.com/prose/prose
 - **Siteleaf** : (web: [siteleaf.com](http://www.siteleaf.com/)) - Online editor content manager that allows you to publish anywhere, including Github Pages, and it has Jekyll support.
 - **Surreal CMS** : (web: [surrealcms.com](http://www.surrealcms.com/)) - Hosted CMS for static sites over FTP or Amazon S3.


### PR DESCRIPTION
I've updated the website for Netlify CMS to point to their official website, as it was previously pointing to their company/hosting website.

I've also added Netlify as a free hosting option.

:)