### PR TITLE
Updated GraphCMS to their current brand name 'Hygraph'

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ We don't want to repeat that content, _go read the original!_
 - **Contentful** : (web: [contentful.com](https://www.contentful.com/features/)) - Enterprise-grade content editing for anything (more than just static sites)
 - **DatoCMS** : (web: [datocms.com](https://www.datocms.com)) - An open source, and commercially supported, CMS for Static Site Generators.  Developed on GitHub: https://github.com/datocms
 - **Forestry** (web: [forestry.io](https://forestry.io)) - A CMS for Jekyll and Hugo sites. Host anywhere (GitHub Pages, Amazon S3, FTP, etc) and access your static CMS from `site.com/admin/`.
-- **GraphCMS** : (web: [graphcms.com](https://graphcms.com/)) - Headless CMS for Digital Creators. GraphQL Content APIs for Digital Products.  Developed on GitHub: https://github.com/GraphCMS
 - **Grav** : (web: [getgrav.org](https://getgrav.org/)) - Modern, Crazy Fast, Ridiculously Easy and Amazingly Powerful Flat-File CMS.
 - **Hokus** : (web: [hokus CMS](https://www.hokuscms.com/)) - Open source CMS for Hugo static websites.
+- **Hygraph** : (web: [hygraph.com](https://hygraph.com/)) - Headless CMS for Digital Creators. GraphQL Content APIs for Digital Products.  Developed on GitHub: https://github.com/hygraph
 - **Jekyll Admin** (web: [jekyll.github.io/jekyll-admin](https://jekyll.github.io/jekyll-admin/)) - A Jekyll plugin that provides users with a traditional CMS-style graphical interface to author content and administer Jekyll sites.  Developed on GitHub: https://github.com/jekyll/jekyll-admin
 - **Netlify** : (web: [netlifycms.org](https://www.netlifycms.org/)) - An open source, and commercially supported, CMS for Static Site Generators.  Developed on GitHub: https://github.com/netlify/netlify-cms
 - **Prose** : (web: [prose.io](http://prose.io/)) - An open source CMS for GitHub pages.  Developed on GitHub: https://github.com/prose/prose


### PR DESCRIPTION
In 2022 [GraphCMS rebranded to Hygraph](https://hygraph.com/blog/graphcms-is-now-hygraph). This PR updates all references to GraphCMS to reflect the new name, Hygraph.