### PR TITLE
Add FreeKit to Free hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ We don't want to repeat that content, _go read the original!_
 - **Neocities** : (web: [neocities.org](https://neocities.org))
 - **Netlify** : (web: [netlify.com](https://www.netlify.com))
 - **DOM Cloud** : (web: [domcloud.id](https://domcloud.id/en/))
+- **FreeKit** : (web: [freekit.dev](https://freekit.dev)) - Free instant HTML hosting API. Upload HTML and get a public URL, no signup required.
 - **Azure Static Web Apps** : (web: [azure.microsoft.com](https://azure.microsoft.com/services/app-service/static/))
 
 ## Commercial hosting


### PR DESCRIPTION
## Summary
- Added [FreeKit](https://freekit.dev) to the **Free hosting** section
- FreeKit is a free instant HTML hosting API — upload HTML and get a public URL, no signup required
- Built with Node.js/TypeScript/Express, backed by Azure Blob Storage

## Details
FreeKit fits naturally in the Free hosting category as it provides free, instant HTML hosting via a simple REST API. It requires no account or signup — just POST your HTML and receive a shareable URL.

Website: https://freekit.dev