### PR TITLE
feat(hosting provider): add Zoho Catalyst Slate

### DIFF
--- a/Hosting Providers.toml
+++ b/Hosting Providers.toml
@@ -78,3 +78,10 @@ url = "https://www.netlify.com"
 description = "Free tier static hosting with CDN, continuous deployment, form handling, and serverless functions."
 tags = ["free", "private company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/47"
+
+[[providers]]
+name = "Zoho Catalyst Slate"
+url = "https://catalyst.zoho.com/slate/index.html?src=header"
+description = "Free tier static hosting instantly from your Github repos(not limited to) with automatic scaling and with integrated databases, authentication, serverless functions, and event handling"
+tags = ["big tech", "cdn", "free", "global", "hosting"]
+issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/63"

--- a/Hosting Providers.toml
+++ b/Hosting Providers.toml
@@ -81,7 +81,7 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 
 [[providers]]
 name = "Zoho Catalyst Slate"
-url = "https://catalyst.zoho.com/slate/index.html?src=header"
+url = "https://catalyst.zoho.com/slate/"
 description = "Free tier static hosting instantly from your Github repos(not limited to) with automatic scaling and with integrated databases, authentication, serverless functions, and event handling"
 tags = ["big tech", "cdn", "free", "global", "hosting"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/63"

--- a/Hosting Providers.toml
+++ b/Hosting Providers.toml
@@ -82,6 +82,6 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 [[providers]]
 name = "Zoho Catalyst Slate"
 url = "https://catalyst.zoho.com/slate/"
-description = "Free tier static hosting instantly from your Github repos(not limited to) with automatic scaling and with integrated databases, authentication, serverless functions, and event handling"
+description = "Free tier static hosting instantly from your GitHub repositories (not limited to) with automatic scaling and integrated databases, authentication, serverless functions, and event handling."
 tags = ["big tech", "cdn", "free", "global", "hosting"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/63"

--- a/Hosting Providers.toml
+++ b/Hosting Providers.toml
@@ -83,5 +83,5 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 name = "Zoho Catalyst Slate"
 url = "https://catalyst.zoho.com/slate/"
 description = "Free tier static hosting instantly from your GitHub repositories (not limited to) with automatic scaling and integrated databases, authentication, serverless functions, and event handling."
-tags = ["big tech", "cdn", "free", "global", "hosting"]
+tags = ["big tech", "free", "private company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/63"

--- a/Hosting Providers.toml
+++ b/Hosting Providers.toml
@@ -20,14 +20,14 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 name = "AWS S3"
 url = "https://aws.amazon.com/s3/"
 description = "Object storage from Amazon Web Services widely used for static site hosting with CloudFront CDN."
-tags = ["public company", "global"]
+tags = ["big tech", "public company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/53"
 
 [[providers]]
 name = "Azure Static Web Apps"
 url = "https://azure.microsoft.com/en-us/products/app-service/static"
 description = "Free tier static hosting from Microsoft Azure with global CDN and GitHub Actions integration."
-tags = ["free", "public company", "global"]
+tags = ["big tech", "free", "public company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/49"
 
 [[providers]]
@@ -55,14 +55,14 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 name = "GitHub Pages"
 url = "https://pages.github.com"
 description = "Free static site hosting directly from a GitHub repository. Supports custom domains and HTTPS."
-tags = ["free", "public company", "global"]
+tags = ["big tech", "free", "public company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/44"
 
 [[providers]]
 name = "GitLab Pages"
 url = "https://docs.gitlab.com/ee/user/project/pages/"
 description = "Free static hosting built into GitLab, with CI/CD integration and custom domain support."
-tags = ["free", "public company", "global"]
+tags = ["big tech", "free", "public company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/45"
 
 [[providers]]
@@ -76,7 +76,7 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 name = "Netlify"
 url = "https://www.netlify.com"
 description = "Free tier static hosting with CDN, continuous deployment, form handling, and serverless functions."
-tags = ["free", "private company", "global"]
+tags = ["big tech", "free", "private company", "global"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/47"
 
 [[providers]]


### PR DESCRIPTION
## Summary

hosting provider Zoho Catalyst Slate

## Checklist

- [x] TOML entries are sorted (`just check-toml`)
- [x] Tested locally (`just dev`)

## Preview

To preview this PR's site locally:

```
just preview-pr 68
```

Pass `no-serve=1` to build only (no dev server), or `keep-dir=1` to keep the build output after exit.
Requires [just](https://just.systems/), [git](https://git-scm.com/), and [uv](https://docs.astral.sh/uv/) to be installed.

Fixes https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/63
