### PR TITLE
fix(cms): migrate "Forestry" to "Tina CMS"

### DIFF
--- a/Content Management Systems.toml
+++ b/Content Management Systems.toml
@@ -75,6 +75,6 @@ issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/
 [[systems]]
 name = "Tina CMS"
 source_url = "https://github.com/tinacms/tinacms"
-description = " A fully open-source headless CMS that supports Markdown and Visual Editing."
+description = "A fully open-source headless CMS that supports Markdown and Visual Editing."
 tags = ["blogging", "git-based", "hosted", "open-source", "self-hosted"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/34"

--- a/Content Management Systems.toml
+++ b/Content Management Systems.toml
@@ -24,13 +24,6 @@ tags = ["javascript", "git-based", "open-source", "blogging"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/39"
 
 [[systems]]
-name = "Forestry"
-source_url = ""
-description = "Git-based CMS for Jekyll and Hugo sites. Host anywhere and access your CMS from /admin/."
-tags = ["git-based", "blogging", "hosted"]
-issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/34"
-
-[[systems]]
 name = "Grav"
 source_url = "https://github.com/getgrav/grav"
 description = "Modern, fast flat-file CMS built on PHP. No database required."
@@ -78,3 +71,10 @@ source_url = ""
 description = "Hosted CMS for static sites over FTP or Amazon S3. Edit HTML pages in-browser."
 tags = ["hosted", "blogging"]
 issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/43"
+
+[[systems]]
+name = "Tina CMS"
+source_url = "https://github.com/tinacms/tinacms"
+description = " A fully open-source headless CMS that supports Markdown and Visual Editing."
+tags = ["blogging", "git-based", "hosted", "open-source", "self-hosted"]
+issue = "https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/34"


### PR DESCRIPTION
## Summary

fix(cms): migrate "Forestry" to "Tina CMS"

Note: Forestry is now TinaCMS.

From the Wayback Machine: https://web.archive.org/web/20230506230704/https://tina.io/forestry/ 

## Checklist

- [x] TOML entries are sorted (`just check-toml`)
- [x] Tested locally (`just dev`)

See also: https://github.com/MooseTheRebel/awesome-static-hosting-and-cms/issues/34

## Preview

To preview this PR's site locally:

```
just preview-pr <PR_number>
```

Pass `no-serve=1` to build only (no dev server), or `keep-dir=1` to keep the build output after exit.
Requires [just](https://just.systems/), [git](https://git-scm.com/), and [uv](https://docs.astral.sh/uv/) to be installed.
