### PR TITLE
feat: add simple-datatables

### DIFF
--- a/github_site/templates/cms.html
+++ b/github_site/templates/cms.html
@@ -1,11 +1,11 @@
-{% extends "coltrane/base.html" %}
+{% extends "table_base.html" %}
 
-{% block content %}
+{% block table_content %}
 <h1>Content Management Systems</h1>
 <p>A curated directory of content management systems compatible with static site generators.
    Each entry links to a GitHub issue in this repository for community discussion.</p>
 
-<table>
+<table class="data-table">
   <thead>
     <tr>
       <th>Name</th>
@@ -43,4 +43,4 @@
     {% endfor %}
   </tbody>
 </table>
-{% endblock content %}
+{% endblock table_content %}

--- a/github_site/templates/hosting-providers.html
+++ b/github_site/templates/hosting-providers.html
@@ -1,11 +1,11 @@
-{% extends "coltrane/base.html" %}
+{% extends "table_base.html" %}
 
-{% block content %}
+{% block table_content %}
 <h1>Static Hosting Providers</h1>
 <p>A curated directory of static site hosting providers.
    Each entry links to a GitHub issue in this repository for community discussion.</p>
 
-<table>
+<table class="data-table">
   <thead>
     <tr>
       <th>Name</th>
@@ -35,4 +35,4 @@
     {% endfor %}
   </tbody>
 </table>
-{% endblock content %}
+{% endblock table_content %}

--- a/github_site/templates/table_base.html
+++ b/github_site/templates/table_base.html
@@ -1,0 +1,43 @@
+{% extends "coltrane/base.html" %}
+
+{% block content %}
+<link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
+
+{% block table_content %}{% endblock table_content %}
+
+<script type="module">
+  import { DataTable } from "https://cdn.jsdelivr.net/npm/simple-datatables@latest/+esm"
+  document.querySelectorAll(".data-table").forEach((table) => {
+    new DataTable(table, {
+      perPageSelect: [10, 50, ["All", -1]],
+      tableRender: (_data, tableElement, type) => {
+        if (type === "print") {
+          return tableElement
+        }
+        const tHead = tableElement.childNodes[0]
+        const filterHeaders = {
+          nodeName: "TR",
+          childNodes: tHead.childNodes[0].childNodes.map(
+            (_th, colIndex) => ({
+              nodeName: "TH",
+              childNodes: [
+                {
+                  nodeName: "INPUT",
+                  attributes: {
+                    class: "datatable-input",
+                    type: "search",
+                    placeholder: "Search...",
+                    "data-columns": `[${colIndex}]`
+                  }
+                }
+              ]
+            })
+          )
+        }
+        tHead.childNodes.push(filterHeaders)
+        return tableElement
+      }
+    })
+  })
+</script>
+{% endblock content %}

--- a/github_site/templates/table_base.html
+++ b/github_site/templates/table_base.html
@@ -1,7 +1,7 @@
 {% extends "coltrane/base.html" %}
 
 {% block content %}
-<link href="https://cdn.jsdelivr.net/npm/simple-datatables@10.2.0/dist/style.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/simple-datatables@10.2.0/dist/style.css" rel="stylesheet" type="text/css" integrity="sha384-CinX6s1UC1GpaQwL9eKshF7JhtC8H2xchDD0dWqlCgZ8t+GCCcjluxCgmsbVpdEh" crossorigin="anonymous">
 
 {% block table_content %}{% endblock table_content %}
 

--- a/github_site/templates/table_base.html
+++ b/github_site/templates/table_base.html
@@ -1,12 +1,12 @@
 {% extends "coltrane/base.html" %}
 
 {% block content %}
-<link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
+<link href="https://cdn.jsdelivr.net/npm/simple-datatables@10.2.0/dist/style.css" rel="stylesheet" type="text/css">
 
 {% block table_content %}{% endblock table_content %}
 
 <script type="module">
-  import { DataTable } from "https://cdn.jsdelivr.net/npm/simple-datatables@latest/+esm"
+  import { DataTable } from "https://cdn.jsdelivr.net/npm/simple-datatables@10.2.0/+esm"
   document.querySelectorAll(".data-table").forEach((table) => {
     new DataTable(table, {
       perPageSelect: [10, 50, ["All", -1]],
@@ -14,10 +14,14 @@
         if (type === "print") {
           return tableElement
         }
-        const tHead = tableElement.childNodes[0]
+        const tHead = tableElement.childNodes.find(node => node.nodeName === "THEAD")
+        if (!tHead) return tableElement
+        const headerRow = tHead.childNodes.find(node => node.nodeName === "TR")
+        if (!headerRow) return tableElement
+        const thNodes = headerRow.childNodes.filter(node => node.nodeName === "TH")
         const filterHeaders = {
           nodeName: "TR",
-          childNodes: tHead.childNodes[0].childNodes.map(
+          childNodes: thNodes.map(
             (_th, colIndex) => ({
               nodeName: "TH",
               childNodes: [


### PR DESCRIPTION
## Summary

Adds [simple-datatables](https://github.com/fiduswriter/simple-datatables/) to the table UIs.


## Checklist

- [ ] TOML entries are sorted (`just check-toml`)
- [ ] Tested locally (`just dev`)

## Preview

To preview this PR's site locally:

```
just preview-pr <PR_number>
```

Pass `no-serve=1` to build only (no dev server), or `keep-dir=1` to keep the build output after exit.
Requires [just](https://just.systems/), [git](https://git-scm.com/), and [uv](https://docs.astral.sh/uv/) to be installed.
